### PR TITLE
Create an Overview class

### DIFF
--- a/app/models/entity/entity.js
+++ b/app/models/entity/entity.js
@@ -47,9 +47,9 @@ class Entity extends IncidentedBase {
     }
 
     if (labelKey) {
-      this.overviewDescription = this.getLabel(labelKey, labelPrefix, {
+      this.overview.setDescription(this.getLabel(labelKey, labelPrefix, {
         name: this.getData('name'),
-      });
+      }));
     }
   }
 
@@ -104,10 +104,10 @@ class Entity extends IncidentedBase {
     }
 
     if (labelKey) {
-      this.overviewDetails = this.getLabel(labelKey, labelPrefix, {
+      this.overview.setDetails(this.getLabel(labelKey, labelPrefix, {
         domain: domainString,
         locations: locationsString,
-      });
+      }));
     }
   }
 

--- a/app/models/person/person.js
+++ b/app/models/person/person.js
@@ -60,9 +60,9 @@ class Person extends IncidentedBase {
     }
 
     if (labelKey) {
-      this.overviewDescription = this.getLabel(labelKey, labelPrefix, {
+      this.overview.setDescription(this.getLabel(labelKey, labelPrefix, {
         name: this.getData('name'),
-      });
+      }));
     }
   }
 
@@ -121,7 +121,7 @@ class Person extends IncidentedBase {
     }
 
     if (details.length) {
-      this.overviewDetails = details.join(' ');
+      this.overview.setDetails(details.join(' '));
     }
   }
 

--- a/app/models/shared/base-incidented.js
+++ b/app/models/shared/base-incidented.js
@@ -3,6 +3,8 @@ const Role = require('../role');
 
 const { percentage } = require('../../lib/number');
 
+const Overview = require('./overview');
+
 class IncidentedBase extends Base {
   static labelPrefix = null;
   static linkKey = null;
@@ -19,20 +21,14 @@ class IncidentedBase extends Base {
     return this.roleCollections.includes(collection);
   }
 
-  overviewProps = [
-    'first',
-    'last',
-    'percentage',
-    'total',
-  ];
-
-  overviewDescription = null;
-  overviewDetails = null;
-
   role = null;
 
   globalIncidentCount = null;
   globalIncidentPercentage = null;
+
+  configureOtherValues() {
+    super.overview = new Overview();
+  }
 
   setRole(role) {
     if (this.constructor.isValidRoleOption(role)) {
@@ -41,6 +37,10 @@ class IncidentedBase extends Base {
       this.role.setLabelPrefix(this.constructor.singular());
       this.role.initCollections(this.constructor.roleCollections);
     }
+  }
+
+  hasOverview() {
+    return this.overview !== null && this.overview.hasValues();
   }
 
   hasRole() {
@@ -87,47 +87,27 @@ class IncidentedBase extends Base {
     return 'total' in this.data && typeof this.data.total === 'number';
   }
 
-  setOverviewObject() {
-    this.setData('overview', {
-      label: this.constructor.getLabel('overview'),
-      labels: {
-        intro: this.overviewDescription,
-        details: this.overviewDetails,
-        title: this.constructor.getLabel('overview'),
-      },
-    });
-  }
-
   setOverviewAppearances(stats) {
-    this.data.overview.appearances = {
+    this.overview.setAppearances({
       label: this.constructor.getLabel('appearances'),
       values: {},
-    };
+    });
 
     if (this.statsHasFirstIncident(stats)) {
-      this.setOverviewAppearanceValue('first', stats.first);
+      this.overview.setAppearancesValue('first', stats.first);
     }
 
     if (this.statsHasLastIncident(stats)) {
-      this.setOverviewAppearanceValue('last', stats.last);
+      this.overview.setAppearancesValue('last', stats.last);
     }
   }
 
-  setOverviewAppearanceValue(key, value) {
-    this.data.overview.appearances.values[key] = {
-      key,
-      label: this.constructor.getLabel(key, 'appearances'),
-      value,
-    };
-  }
-
   setOverviewTotals() {
-    this.data.overview.totals = {
+    this.overview.setTotals({
       label: this.constructor.getLabel('totals'),
       values: {},
-    };
-
-    this.setOverviewTotalValue(this.data.total);
+    });
+    this.overview.setTotalsValue('total', this.data.total);
 
     if (this.hasGlobalIncidentCount() || this.hasGlobalIncidentPercentage()) {
       let value;
@@ -139,45 +119,23 @@ class IncidentedBase extends Base {
       }
 
       if (value) {
-        this.setOverviewPercentageValue(value);
+        this.overview.setTotalsValue('percentage', `${value}%`);
       }
     }
   }
 
-  setOverviewTotalValue(value) {
-    this.data.overview.totals.values.total = {
-      key: 'total',
-      label: this.constructor.getLabel('total', 'incidents'),
-      value,
-    };
-  }
-
-  setOverviewPercentageValue(value) {
-    this.data.overview.totals.values.percentage = {
-      key: 'percentage',
-      label: this.constructor.getLabel('percentage', 'incidents'),
-      value: `${value}%`,
-    };
-  }
-
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   setOverviewDescription(values = {}) {
-    this.overviewDescription = null;
-  }
-
-  hasOverviewDescription() {
-    return this.overviewDescription !== null;
+    this.overview.setDescription();
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   setOverviewDetails(values = {}) {
-    this.overviewDetails = null;
+    this.overview.setDetails();
   }
 
   setOverview(stats = {}) {
-    this.setOverviewObject();
-
-    if (this.dataHasTotal() || this.overviewProps.some(prop => prop in stats)) {
+    if (this.dataHasTotal() || Overview.props.some(prop => prop in stats)) {
       if (this.statsHasTotal(stats)) {
         this.setData('total', stats.total);
       }
@@ -220,8 +178,8 @@ class IncidentedBase extends Base {
       adapted.incidents = result.incidents;
     }
 
-    if (result.overview) {
-      adapted.overview = result.overview;
+    if (this.hasOverview()) {
+      adapted.overview = this.overview.toObject();
     }
 
     return adapted;

--- a/app/models/shared/overview.js
+++ b/app/models/shared/overview.js
@@ -1,0 +1,99 @@
+const { Labels } = require('../../helpers/labels');
+
+class Overview {
+  static {
+    this.labels = new Labels();
+  }
+
+  static props = [
+    'first',
+    'last',
+    'percentage',
+    'total',
+  ];
+
+  description = null;
+  details = null;
+
+  appearances = null;
+  totals = null;
+
+  getLabel(key, prefix) {
+    return this.constructor.labels.getLabel(key, prefix);
+  }
+
+  setDescription(description) {
+    this.description = description;
+  }
+
+  hasDescription() {
+    return this.description !== null;
+  }
+
+  setDetails(details) {
+    this.details = details;
+  }
+
+  hasDetails() {
+    return this.details !== null;
+  }
+
+  setAppearances(appearances) {
+    this.appearances = appearances;
+  }
+
+  hasAppearances() {
+    return this.appearances !== null;
+  }
+
+  setAppearancesValue(key, value) {
+    this.appearances.values[key] = {
+      key,
+      label: this.getLabel(key, 'appearances'),
+      value,
+    };
+  }
+
+  setTotals(totals) {
+    this.totals = totals;
+  }
+
+  hasTotals() {
+    return this.totals !== null;
+  }
+
+  setTotalsValue(key, value) {
+    this.totals.values[key] = {
+      key,
+      label: this.getLabel(key, 'incidents'),
+      value,
+    };
+  }
+
+  hasValues() {
+    return this.hasDescription() || this.hasDetails() || this.hasAppearances() || this.hasTotals();
+  }
+
+  toObject() {
+    const obj = {
+      label: this.getLabel('overview'),
+      labels: {
+        intro: this.description,
+        details: this.details,
+        title: this.getLabel('overview'),
+      },
+    };
+
+    if (this.hasAppearances()) {
+      obj.appearances = this.appearances;
+    }
+
+    if (this.hasTotals()) {
+      obj.totals = this.totals;
+    }
+
+    return obj;
+  }
+}
+
+module.exports = Overview;

--- a/app/models/source/source.js
+++ b/app/models/source/source.js
@@ -47,13 +47,13 @@ class Source extends IncidentedBase {
     }
 
     if (labelKey) {
-      this.overviewDescription = this.getLabel(labelKey, labelPrefix, {
+      this.overview.setDescription(this.getLabel(labelKey, labelPrefix, {
         date: this.constructor.readableDate(this.getData('retrieved_at')),
         format: this.readableFormat(this.getData('format')),
         source_publication: this.getLabel('website_auditor', labelPrefix), // eslint-disable-line camelcase
         title: this.getData('title'),
         url: this.getData('public_url'),
-      });
+      }));
     }
   }
 
@@ -74,7 +74,7 @@ class Source extends IncidentedBase {
     }
 
     if (labelKey) {
-      this.overviewDetails = this.getLabel(labelKey, labelPrefix);
+      this.overview.setDetails(this.getLabel(labelKey, labelPrefix));
     }
   }
 


### PR DESCRIPTION
## What changes does this PR introduce?

Moves creation of the item (entity, person, source) overview object out to a separate `Overview` class. A little more to do on this ... sometime.

## Affected path or paths

- `/entities/:id`
- `/people/:id`
- `/sources/:id`

## UI changes

None